### PR TITLE
PLA-8178: bump to version 0.19.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,8 +41,8 @@ let package = Package(
             ]
     ), 
     .binaryTarget(name: "TyroTapToPaySDK",
-                  url: "https://tap-to-pay.connect.tyro.com/tyro/0.19.3/TyroTapToPaySDK.xcframework.zip",
-                  checksum: "a10eba4d8c74fe2cea79c476806099534d27c93e910e3d43b82e8319a5b27cc5"),
+                  url: "https://tap-to-pay.connect.tyro.com/tyro/0.19.4/TyroTapToPaySDK.xcframework.zip",
+                  checksum: "8536b3ecb078e8c6686ea2bc900c8aa51185024454ec7c25cf0ee9ad2b40ec4c"),
     .binaryTarget(name: "MobileConfiguration",
                 url: "https://tap-to-pay.connect.tyro.com/ss/1.0.11.0/SSMobileConfiguration.xcframework.zip",
                 checksum: "534ca37dd83f03b34cd66393b5011c7b9f307fd8dea6fdb2f074bbdc0269e33f"),


### PR DESCRIPTION
- Increase sheet detents for surcharge pop-up screen

| iPhone SE (2nd generation) | iPhone 14 |
|--|--|
|![](https://github.com/user-attachments/assets/be557b08-be5e-444b-a452-4452868676e7)|![](https://github.com/user-attachments/assets/f4771e9c-fc64-4831-847d-11d39b8d6c21)|


